### PR TITLE
pip10+ compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,13 @@
 import os
 import sys
 import re
-import pip
-from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
+from setuptools import setup, find_packages
+
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
@@ -19,11 +22,11 @@ with open('README.md') as f:
 
 # Handle requirements
 requires = parse_requirements("requirements/install.txt",
-                              session=pip.download.PipSession())
+                              session='pip10hack')
 install_requires = [str(ir.req) for ir in requires]
 
 requires = parse_requirements("requirements/tests.txt",
-                              session=pip.download.PipSession())
+                              session='pip10hack')
 tests_require = [str(ir.req) for ir in requires]
 
 # Convert markdown to rst


### PR DESCRIPTION
Fixes setup.py so that the module can be installed using newer versions of pip.

Eventually setup.py should be re-written using the newer process but this workaround allows installation.